### PR TITLE
fix title tag, add more metadata tags

### DIFF
--- a/recorder.sh
+++ b/recorder.sh
@@ -28,7 +28,11 @@ while true; do
 		string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
 
 	artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
-	title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")') 
+    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
+    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs)
+	title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-')
+    trk=$(echo $spotify_metadata | grep -o 'trackNumber.*url' | grep -o ' [0-9].*)' | tr -d ' )')
+    printf -v track "%02d" $trk
 
 	if [ -z "$artist" ]; then
 		killall ffmpeg 2> /dev/null
@@ -44,8 +48,8 @@ while true; do
 
 	current_record_artist=$artist
 	current_record_title=$title
-	filename="${music_folder}${artist}- ${title::-1}.mp3"
+    filename="${music_folder}${artist}- ${title::-1}.mp3"
 	
 	ffmpeg -hide_banner -loglevel panic -nostats  -f pulse -ac 2 -i "$pulse_sink" \
-		-metadata title="$title" -metadata artist="$artist" "$filename" &
+		-metadata title="$title" -metadata artist="$artist" -metadata album="$album" -metadata album_artist="$albumartist" -metadata track="$track" "$filename" &
 done


### PR DESCRIPTION
Thanks for making this handy little script. It works better than some others I tried. I added a few extras that I found improved it a bit.

This PR fixes the title tag so that slash (/) doesn't cause track fail. Sometimes titles can have a slash used for dates or fractions. I had this several times with live tracks that had date in title. This replaces the slash with dash.

Also, adds several new tags: track, album, album artist. These are nice to have set in file. In particular the track # can be a real pain to have to do manually for every track. 

I did not add code for using the tags in filename/path but my personal version uses track and album in the path/filename. I thought of adding a command line option to switch on that kind of thing. If interested I'll implement but for now it's fairly easy to alter the output path to use a tag. That could be another PR.
