### PR TITLE
add options for help, filepath tags support [ -h,-a,-f ]

### DIFF
--- a/recorder.sh
+++ b/recorder.sh
@@ -56,16 +56,12 @@ while true; do
     spotify_metadata=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
         /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
-
-    artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
-    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
-    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-')
-    title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-')
-    trk=$(echo $spotify_metadata | grep -o 'trackNumber.*url' | grep -o ' [0-9].*)' | tr -d ' )')
-    album=${album%% }
-    artist=${artist%% }
-    albumartist=${albumartist%% }
-    title=${title%% }
+	readarray -t data <<<$(echo $spotify_metadata | grep -Eo '"[^"]*"| [0-9]+' | tr -d '"' | tr '/' '-')
+	album=${data[7]}
+	albumartist=${data[9]}
+	artist=${data[11]}
+	title=${data[17]}
+	trk=${data[19]}
     printf -v track "%02d" $trk
 
     if [ -z "$artist" ]; then

--- a/recorder.sh
+++ b/recorder.sh
@@ -56,13 +56,13 @@ while true; do
     spotify_metadata=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
         /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
-	readarray -t data <<<$(echo $spotify_metadata | grep -Eo '"[^"]*"| [0-9]+' | tr -d '"' | tr '/' '-')
-	album=${data[7]}
-	albumartist=${data[9]}
-	artist=${data[11]}
-	title=${data[17]}
-	trk=${data[19]}
-    printf -v track "%02d" $trk
+	readarray -t data <<<$(echo $spotify_metadata | grep -Po '"(?:[^"\\]|\\.)*"| [0-9]+' |sed 's/\\"/"/g' | tr '/' '-')
+	#readarray -t data <<<$(echo $spotify_metadata | grep -Eo '"[^"]*"| [0-9]+' | tr -d '"' | tr '/' '-')
+	album=${data[7]:1:-1}
+	albumartist=${data[9]:1:-1}
+	artist=${data[11]:1:-1}
+	title=${data[17]:1:-1}
+    printf -v track "%02d" ${data[19]}
 
     if [ -z "$artist" ]; then
         killall ffmpeg 2> /dev/null

--- a/recorder.sh
+++ b/recorder.sh
@@ -58,6 +58,8 @@ while true; do
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
 	readarray -t data <<<$(echo $spotify_metadata | grep -Po '"(?:[^"\\]|\\.)*"| [0-9]+' |sed 's/\\"/"/g' | tr '/' '-')
 	#readarray -t data <<<$(echo $spotify_metadata | grep -Eo '"[^"]*"| [0-9]+' | tr -d '"' | tr '/' '-')
+	arturl=${data[5]:1:-1}
+	arturl="https://i.scdn.co/image/"${arturl##*-}  # fixup for buggy art url metadata
 	album=${data[7]:1:-1}
 	albumartist=${data[9]:1:-1}
 	artist=${data[11]:1:-1}
@@ -79,9 +81,14 @@ while true; do
     current_record_artist=$artist
     current_record_title=$title
     expand_filename
-    mkdir -p "$(dirname "$filename")"
+    recdir="$(dirname "$filename")"
+    mkdir -p "$recdir"
     echo "Recording to $filename"
     
     ffmpeg -hide_banner -loglevel panic -nostats  -f pulse -ac 2 -i "$pulse_sink" \
         -metadata title="$title" -metadata artist="$artist" -metadata album="$album" -metadata album_artist="$albumartist" -metadata track="$track" "$filename" &
+    
+    if [ ! -f "$recdir/folder.jpg" ]; then
+		wget "$arturl" -q -O "$recdir/folder.jpg"
+    fi
 done

--- a/recorder.sh
+++ b/recorder.sh
@@ -57,11 +57,15 @@ while true; do
         /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
 
-    artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs -0)
-    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs -0)
-    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs -0)
-    title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs -0)
+    artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
+    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]')
+    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-')
+    title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-')
     trk=$(echo $spotify_metadata | grep -o 'trackNumber.*url' | grep -o ' [0-9].*)' | tr -d ' )')
+    album=${album%% }
+    artist=${artist%% }
+    albumartist=${albumartist%% }
+    title=${title%% }
     printf -v track "%02d" $trk
 
     if [ -z "$artist" ]; then

--- a/recorder.sh
+++ b/recorder.sh
@@ -57,10 +57,10 @@ while true; do
         /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
 
-    artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs)
-    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs)
-    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs)
-    title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs)
+    artist=$(echo $spotify_metadata | grep -o 'artist.*autoRating' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs -0)
+    albumartist=$(echo $spotify_metadata | grep -o 'albumArtist.*artist' | grep -o '"[a-zA-Z0-9].* ]' | tr -d '"]' |xargs -0)
+    album=$(echo $spotify_metadata | grep -o 'album.*albumArtist' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs -0)
+    title=$(echo $spotify_metadata | grep -o 'title.*trackNumber' | grep -o '"[a-zA-Z0-9].*)' | tr -d '")' | tr '/' '-' |xargs -0)
     trk=$(echo $spotify_metadata | grep -o 'trackNumber.*url' | grep -o ' [0-9].*)' | tr -d ' )')
     printf -v track "%02d" $trk
 

--- a/recorder.sh
+++ b/recorder.sh
@@ -57,13 +57,13 @@ while true; do
     spotify_metadata=$(dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify \
         /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get \
         string:org.mpris.MediaPlayer2.Player string:Metadata 2>/dev/null)
-    readarray -t data <<<$(echo $spotify_metadata | grep -Po '"(?:[^"\\]|\\.)*"| [0-9]+' |sed 's/\\"/"/g' | tr '/' '-')
-    arturl=${data[5]:1:-1}
+    readarray -t data <<<$(echo $spotify_metadata | grep -Po '".*?" (\)|v|])| [0-9]+' | tr '/' '-')
+    arturl=${data[5]:1:-3}
     arturl="https://i.scdn.co/image/"${arturl##*-}  # fixup for buggy art url metadata
-    album=${data[7]:1:-1}
-    albumartist=${data[9]:1:-1}
-    artist=${data[11]:1:-1}
-    title=${data[17]:1:-1}
+    album=${data[7]:1:-3}
+    albumartist=${data[9]:1:-3}
+    artist=${data[11]:1:-3}
+    title=${data[17]:1:-3}
     printf -v track "%02d" ${data[19]}
 
     if [ -z "$artist" ]; then
@@ -90,7 +90,6 @@ while true; do
     mkdir -p "$recdir"
 
     echo "Recording to $filename"
-    
     ffmpeg -hide_banner -loglevel panic -nostats  -f pulse -ac 2 -i "$pulse_sink" \
         -metadata title="$title" -metadata artist="$artist" -metadata album="$album" -metadata album_artist="$albumartist" -metadata track="$track" "$filename" &
 


### PR DESCRIPTION
This is preliminary PR for help and tag var substitution options. 

See Issue #2 for more explanation and discussion. I'm completely open to making changes before it gets merged.

Note - I fixed the tag parsing by adding xargs to some without. That just strips leading/trailing white space. It's better than having to use ${var::-1} notation (that was used previously).

I have tested both -a and -f options here but not yet verified that everything else works as before. It should get more testing.

Also, I use a function to delay tag var expansion until needed and global args variable to allow -f to likewise delay command line arg expansion til after each track tags extracted.